### PR TITLE
Automate tests and minor improvements

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,0 +1,27 @@
+name: Run tests
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install .
+      - name: Test with pytest
+        run: |
+          pip install pytest
+          pytest
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -158,3 +158,8 @@ exclude_lines = [
   "if __name__ == .__main__.:",
   "if TYPE_CHECKING:",
 ]
+
+[tool.pytest.ini_options]
+pythonpath = [
+  "src"
+]

--- a/src/morphosource/search.py
+++ b/src/morphosource/search.py
@@ -2,7 +2,7 @@ import os
 import requests
 from morphosource.fetch import fetch_items, fetch_item
 from morphosource.exceptions import ItemNotFound
-from morphosource.download import download_media_bundle, DownloadVisibility
+from morphosource.download import download_media_bundle, get_download_media_zip_url, DownloadVisibility
 from morphosource.config import Endpoints
 
 
@@ -33,6 +33,9 @@ class Media(object):
 
     def download_bundle(self, path, download_config):
         download_media_bundle(media_id=self.id, path=path, download_config=download_config)
+
+    def get_download_bundle_url(self, download_config):
+        return get_download_media_zip_url(media_id=self.id, download_config=download_config)
 
 
 class PhysicalObject(object):

--- a/src/morphosource/search.py
+++ b/src/morphosource/search.py
@@ -37,6 +37,9 @@ class Media(object):
     def get_download_bundle_url(self, download_config):
         return get_download_media_zip_url(media_id=self.id, download_config=download_config)
 
+    def get_website_url(self):
+        return f"https://www.morphosource.org/concern/media/{self.id}"
+
 
 class PhysicalObject(object):
     def __init__(self, data):

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -1,7 +1,8 @@
 import unittest
 import requests
 from unittest.mock import patch, Mock, mock_open
-from morphosource.download import download_media_bundle, DownloadConfig, Endpoints
+from morphosource.download import download_media_bundle, get_download_media_zip_url, \
+    DownloadConfig, Endpoints
 from morphosource.exceptions import RestrictedDownloadError
 
 
@@ -46,3 +47,13 @@ class TestDownload(unittest.TestCase):
         expected_msg = """You do not have authorization to download this restricted media.
 Please visit https://www.morphosource.org and request download permission for media id: 123"""
         self.assertEqual(str(raised_exception.exception), expected_msg)
+
+    @patch("morphosource.download.requests")
+    def test_get_download_bundle_url(self, mock_requests):
+        post_response = Mock()
+        mock_requests.post.return_value = post_response
+        post_response.json.return_value = {"response": {"media": {"download_url": ["someurl"]}}}
+
+        url = get_download_media_zip_url(media_id="1", download_config=download_config)
+
+        self.assertEqual(url, "someurl")

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -1,7 +1,7 @@
 import unittest
 import requests
 from unittest.mock import patch, Mock
-from morphosource.search import search_media, get_media, Endpoints, ItemNotFound, \
+from morphosource.search import search_media, get_media, Media, Endpoints, ItemNotFound, \
     get_object, ObjectTypes, search_objects
 from morphosource.download import DownloadVisibility
 from morphosource.search import Media
@@ -214,3 +214,8 @@ class TestSearch(unittest.TestCase):
 
         ary = obj.get_media_ary(visibility=DownloadVisibility.RESTRICTED)
         mock_search_media.assert_called_with(query='000577960', visibility=DownloadVisibility.RESTRICTED)
+
+    def test_get_website_url(self):
+        media = Media(MS_MEDIA[0])
+        url = media.get_website_url()
+        self.assertEqual(url, "https://www.morphosource.org/concern/media/000390223")


### PR DESCRIPTION
Configures a GitHub action to run tests on push.
Allows users to get the download URL and MorphoSource website URL for a media object.
Fixes #6
Fixes #7
Fixes #10